### PR TITLE
Origin_state double saving removed, bug fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -222,7 +222,6 @@ def MuSA():
                               [j] * grid.shape[0]]
 
                     ifn.safe_pool(spM.spatial_assim, inputs, nprocess)
-                    print(j)
 
                     # Wait untill all ensembles are updated and remove prior
                     spM.wait_for_ensembles(step, 0, j)
@@ -264,5 +263,4 @@ if __name__ == "__main__":
     if cfg.parallelization == "multiprocessing":
         mp.set_start_method('spawn')
     check_platform()
-    mp.set_start_method("spawn")
     MuSA()

--- a/main.py
+++ b/main.py
@@ -222,6 +222,7 @@ def MuSA():
                               [j] * grid.shape[0]]
 
                     ifn.safe_pool(spM.spatial_assim, inputs, nprocess)
+                    print(j)
 
                     # Wait untill all ensembles are updated and remove prior
                     spM.wait_for_ensembles(step, 0, j)
@@ -262,4 +263,5 @@ def check_platform():
 if __name__ == "__main__":
 
     check_platform()
+    mp.set_start_method("spawn")
     MuSA()

--- a/modules/fsm_tools.py
+++ b/modules/fsm_tools.py
@@ -431,6 +431,7 @@ def storeOL(OL_FSM, Ensemble, observations_sbst, time_dict, step):
 
     # Store colums
     for n, name_col in enumerate(ol_data.columns):
+        #OL_FSM[name_col] = ol_data.iloc[range(time_dict['Assimilaiton_steps'][1]), [n]].to_numpy()
         OL_FSM[name_col] = ol_data.iloc[:, [n]].to_numpy()
 
 

--- a/modules/spatialMuSA.py
+++ b/modules/spatialMuSA.py
@@ -848,7 +848,7 @@ def create_ensemble_cell(lat_idx, lon_idx, ini_DA_window, step, gsc_count):
                                 time_dict["Assimilaiton_steps"][step + 1]]\
         .copy()
 
-    Ensemble.create(forcing_sbst, observations_sbst, error_sbst, step)
+    #Ensemble.create(forcing_sbst, observations_sbst, error_sbst, step)
 
     if time_dict["Assimilaiton_steps"][step] in ini_DA_window:
         GSC_filename = (str(gsc_count) + '_GSC.nc')
@@ -1056,10 +1056,10 @@ def collect_results(lat_idx, lon_idx):
     ini_DA_window = domain_steps()
 
     # create filenames
-    DA_Results = ifn.init_result(del_t, DA=True)
-    updated_FSM = ifn.init_result(del_t)
-    sd_FSM = ifn.init_result(del_t)
-    OL_FSM = ifn.init_result(del_t)
+    DA_Results = model.init_result(del_t, DA=True)
+    updated_FSM = model.init_result(del_t)
+    sd_FSM = model.init_result(del_t)
+    OL_FSM = model.init_result(del_t)
 
     # HACK: fake time_dict
     time_dict = {'Assimilaiton_steps':
@@ -1103,10 +1103,10 @@ def collect_results(lat_idx, lon_idx):
             step_results[var_p + "_noise_mean"] = noise_tmp_avg
             step_results[var_p + "_noise_sd"] = noise_tmp_sd
 
-        model.storeDA(DA_Results, step_results, Ensemble.observations,
+        model.storeDA(DA_Results, step_results, Ensemble.observations, Ensemble.errors,
                       time_dict, step)
 
-        model.store_updatedsim(updated_FSM, sd_FSM, Ensemble,
+        model.store_sim(updated_FSM, sd_FSM, Ensemble,
                                time_dict, step)
 
     # the whole OL is stored in the last Ensemble


### PR DESCRIPTION
In create_ensemble_cell, I had that the Ensemble.create() was called twice. That led to have the origin_state being appended two times (in the time dimension) --> I was getting an error in model.storeOL call. So I commented out one of the two calls.
I'm quite sure this modification creates other problems, let me know if there's another better way to do that.

fixed another couple of bugs in the collect_results function.