### PR TITLE
Added IES proposal and RAM algorithm

### DIFF
--- a/modules/filters.py
+++ b/modules/filters.py
@@ -324,13 +324,13 @@ def ProPBS(obs, pred, R, priormean, priorcov, proposal):
 
 
 def mcmc(Ensemble, observations_sbst_masked, R,
-         chain_len=200000, adaptative=True):
+         chain_len=200000, adaptive=True, histcov=True):
 
     vars_to_perturbate = cfg.vars_to_perturbate
     SD0 = np.asarray([cnt.sd_errors[x] for x in vars_to_perturbate])
     m0 = np.asarray([cnt.mean_errors[x] for x in vars_to_perturbate])
 
-    # starting ensemble
+    # starting ensemble 
     starting_parameters = Ensemble.train_parameters[-2]
     starting_parameters = transform_space(starting_parameters, 'to_normal')
     predicted = Ensemble.train_pred[-2][:, 0]
@@ -352,14 +352,23 @@ def mcmc(Ensemble, observations_sbst_masked, R,
     Uc = neglogpost(nll, phic, SD0, m0)
     mcmc_storage = np.zeros((chain_len, len(vars_to_perturbate)))
     mcmc_storage[:] = np.nan
-    sigp = 0.1  # MCMC parameter
+    sigp = 0.1  # Gaussian proposal width. Only used if histcov is False
+    Np=len(vars_to_perturbate)
+    # Using ensemble Kalman methods to speed up the burn in was insired
+    # by Zhang et al. (2020, https://doi.org/10.1029/2019WR025474)
+    if histcov==True: # Posterior IES covariance as proposal covariance
+        Ne=starting_parameters.shape[0]
+        anom=(starting_parameters.T-m0).T
+        C0=(anom@anom.T)/Ne # Posterior covariance of IES (in transformed space)
+    else: # Isotropic covariance as proposal covariance
+        C0=(sigp**2)*np.eye(Np) 
+    Sc=np.linalg.cholesky(C0)
+    Id=np.eye(Np)
+    
     accepted = 0
-
     for nsteps in range(chain_len):
-
-        r = np.random.randn(len(vars_to_perturbate))
-
-        prop = sigp*r
+        r=np.random.randn(Np)
+        prop=Sc@r
         phip = phic+prop
         phip = transform_space(phip.T, 'from_normal').T
 
@@ -405,18 +414,34 @@ def mcmc(Ensemble, observations_sbst_masked, R,
             accepted = accepted + 1
 
         mcmc_storage[nsteps] = phic
+        # IF adaptive, update proposal covariance for next step.
+        # RAM algorithm by Vihola (https://doi.org/10.1007/s11222-011-9269-5)
+        if adaptive==True:
+            mhopt=0.234 # Hard coded hyper-parameters for RAM
+            gam=2.0/3.0
+            stepc=nsteps+1 # Step counter with 1-based indexing.
+            eta=min(1,Np*stepc**(-gam))
+            rinner=r@r
+            router=np.outer(r,r)
+            roi=router/rinner
+            Cp=Sc@(Id+eta*(mh-mhopt)*roi)@(Sc.T)
+            Sc=np.linalg.cholesky(Cp)
+            
+            
 
     # Clean tmp directory
     try:
         shutil.rmtree(os.path.split(temp_dest)[0], ignore_errors=True)
     except TypeError:
         pass
-
+    printstr='mcmc done, acceptance rate=%4.2f' % ((1.0*accepted)/nsteps)
+    print(printstr)
     return accepted, mcmc_storage
 
 
+
 def AI_mcmc(starting_parameters, predicted, observations_sbst_masked, R,
-            chain_len=200000, adaptative=True):
+            chain_len=200000, adaptive=True):
 
     vars_to_perturbate = cfg.vars_to_perturbate
 
@@ -1197,7 +1222,7 @@ def implement_assimilation(Ensemble, step):
             # Run the MCMC
             accepted, mcmc_storage = mcmc(Ensemble, observations_sbst_masked,
                                           r_cov, chain_len=cfg.mcmc_chain_len,
-                                          adaptative=True)
+                                          adaptive=True)
 
             # Burn in:  discard the first 10% samples
             ini = int(mcmc_storage.shape[0] * 0.1)


### PR DESCRIPTION
Just added the IES proposal covariance matrix to IES-MCMC as well as the option of using the adaptive scheme known as Robust Adaptive Metropolis (RAM) rather than plain Random Walk Metropolis (RWM). These changes are both in the mcmc function in modules/filters.py. I have tested that it works at least with the "dIm" model (not FSM) using 20 000 steps and it seems to work nicely producing the expected 0.234 acceptance rate with nice looking posteriors. It does take some time to run though as expected. We can probably improve things further here by scaling the proposal covariance matrix and so forth. 

The options "adaptive=True, histcov=True" ensure that RAM and the IES proposal covariance are used, respectively. adaptive=false would revert to RWM (but still with IES proposal) while histov=False would use the existing (hard coded) isotropic Gaussian proposal based on sigp=0.1 (this would still use a sample from the IES as the initial condition though). So there is the option to run both RWM (apative=false) and RAM (adaptive=true) but not from a "cold start" (starting from the prior), only starting from the IES. It would be nice to allow a cold start as well for comparison, to see how much the IES spees up the MCMC mixing (less burn in period needed).