### PR TITLE
More MCMC updates

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,8 +43,8 @@ ensemble_members = 100
 
 # MCMC parameters
 chain_len = 20000   # Length of the mcmcm
-adaptive = False    # Update proposal covariance for next step.
-histcov = False     # Use posterior IES covariance as proposal covariance
+adaptive = True    # Update proposal covariance for next step.
+histcov = True     # Use posterior IES covariance as proposal covariance
 burn_in = 0.1      # discard the first x proportion of samples
 
 # r_cov can be a list of scalars of length equal to var_to_assim or the string

--- a/config.py
+++ b/config.py
@@ -33,7 +33,7 @@ restart_forcing = False
 
 # da_algorithm from PF, EnKF, IEnKF, PBS, ES, IES, deterministic_OL,
 # IES-MCMC_AI, IES-MCMC, AdaPBS or PIES
-da_algorithm = 'PBS'
+da_algorithm = 'IES-MCMC'
 redraw_prior = False  # PF and PBS only
 max_iterations = 4  # IEnKF, IES, IES-MCMC and AdaPBS
 # resampling_algorithm from "bootstrapping", residual_resample,
@@ -43,8 +43,8 @@ ensemble_members = 100
 
 # MCMC parameters
 chain_len = 20000   # Length of the mcmcm
-adaptive = True    # Update proposal covariance for next step.
-histcov = True     # Use posterior IES covariance as proposal covariance
+adaptive = False    # Update proposal covariance for next step.
+histcov = False     # Use posterior IES covariance as proposal covariance
 burn_in = 0.1      # discard the first x proportion of samples
 
 # r_cov can be a list of scalars of length equal to var_to_assim or the string

--- a/helpers/plot_example.py
+++ b/helpers/plot_example.py
@@ -9,85 +9,89 @@ import numpy as np
 import modules.internal_fns as ifn
 import matplotlib.pyplot as plt
 
-
-output = ifn.io_read('./DATA/RESULTS/cell_0_2.pkl.blp')
-
-obs = output['DA_Results']
-ol = output['OL_Sim']
-sd = output['sd_Sim']
-updated = output['updated_Sim']
-prior_mean = output['prior_mean']
-prior_sd = output['prior_sd']
-try:
-    sdmcmc = output['mcmcSD_Sim']
-    updatedmcmc = output['mcmc_Sim']
-except Exception:
-    pass
-
-# Get obs positions
-x = np.where(~np.isnan(obs['snd']))
-y = obs['snd'][~np.isnan(obs['snd'])]
-ids = np.linspace(1, obs.shape[0], obs.shape[0])
-
-# get and truncate posterior & prior lower marging
-minimun = updated['snd'] - sd['snd']
-minimun[minimun < 0] = 0
-minimun_prior = prior_mean['snd'] - prior_sd['snd']
-minimun_prior[minimun_prior < 0] = 0
-
-try:
-    minimun_mcmc = updatedmcmc['snd'] - sdmcmc['snd']
-    minimun_mcmc[minimun_mcmc < 0] = 0
-except Exception:
-    pass
+# name of the file to be visualized
+output_file = './DATA/RESULTS/cell_0_2.pkl.blp'
 
 
-plt.figure(figsize=(7, 2), dpi=600)
-plt.ylabel("Snow depth [m]")
-props = dict(boxstyle='round', facecolor='white')
-ax = plt.gca()
+def main(name):
+    output = ifn.io_read(name)
 
-plt.fill_between(ids,
-                 minimun_prior,
-                 prior_mean['snd'] + prior_sd['snd'],
-                 color='lightsalmon')
-plt.plot(minimun_prior,
-         color="tomato", lw=0.5, linestyle='dashed')
-plt.plot(prior_mean['snd'] + prior_sd['snd'],
-         color="tomato", lw=0.5, linestyle='dashed')
-plt.plot(prior_mean['snd'], color="red", lw=1,
-         label="Open-loop")
+    obs = output['DA_Results']
+    ol = output['OL_Sim']
+    sd = output['sd_Sim']
+    updated = output['updated_Sim']
+    prior_mean = output['prior_mean']
+    prior_sd = output['prior_sd']
+    try:
+        sdmcmc = output['mcmcSD_Sim']
+        updatedmcmc = output['mcmc_Sim']
+    except Exception:
+        pass
 
-plt.fill_between(ids,
-                 minimun,
-                 updated['snd'] + sd['snd'],
-                 color='mediumaquamarine')
-plt.plot(minimun,
-         color="seagreen", lw=0.5, linestyle='dashed')
-plt.plot(updated['snd'] + sd['snd'],
-         color="seagreen", lw=0.5, linestyle='dashed')
-plt.plot(updated['snd'], color="darkgreen", lw=1,
-         label="Updated")
+    # Get obs positions
+    x = np.where(~np.isnan(obs['snd']))
+    y = obs['snd'][~np.isnan(obs['snd'])]
+    ids = np.linspace(1, obs.shape[0], obs.shape[0])
 
-try:
+    # get and truncate posterior & prior lower marging
+    minimun = updated['snd'] - sd['snd']
+    minimun[minimun < 0] = 0
+    minimun_prior = prior_mean['snd'] - prior_sd['snd']
+    minimun_prior[minimun_prior < 0] = 0
+
+    try:
+        minimun_mcmc = updatedmcmc['snd'] - sdmcmc['snd']
+        minimun_mcmc[minimun_mcmc < 0] = 0
+    except Exception:
+        pass
+
+    plt.figure(figsize=(7, 2), dpi=600)
+    plt.ylabel("Snow depth [m]")
+
     plt.fill_between(ids,
-                     minimun_mcmc,
-                     updatedmcmc['snd'] + sdmcmc['snd'],
-                     color='lightskyblue')
-    plt.plot(updatedmcmc['snd'] + sdmcmc['snd'],
-             color="dodgerblue", lw=0.5, linestyle='dashed')
-    plt.plot(minimun_mcmc,
-             color="dodgerblue", lw=0.5, linestyle='dashed')
-    plt.plot(updatedmcmc['snd'], color="dodgerblue", lw=1,
-             label="Updated-MCMC")
-except Exception:
-    pass
+                     minimun_prior,
+                     prior_mean['snd'] + prior_sd['snd'],
+                     color='lightsalmon')
+    plt.plot(minimun_prior,
+             color="tomato", lw=0.5, linestyle='dashed')
+    plt.plot(prior_mean['snd'] + prior_sd['snd'],
+             color="tomato", lw=0.5, linestyle='dashed')
+    plt.plot(prior_mean['snd'], color="red", lw=1,
+             label="Open-loop")
+
+    plt.fill_between(ids,
+                     minimun,
+                     updated['snd'] + sd['snd'],
+                     color='mediumaquamarine')
+    plt.plot(minimun,
+             color="seagreen", lw=0.5, linestyle='dashed')
+    plt.plot(updated['snd'] + sd['snd'],
+             color="seagreen", lw=0.5, linestyle='dashed')
+    plt.plot(updated['snd'], color="darkgreen", lw=1,
+             label="Updated")
+
+    try:
+        plt.fill_between(ids,
+                         minimun_mcmc,
+                         updatedmcmc['snd'] + sdmcmc['snd'],
+                         color='lightskyblue')
+        plt.plot(updatedmcmc['snd'] + sdmcmc['snd'],
+                 color="dodgerblue", lw=0.5, linestyle='dashed')
+        plt.plot(minimun_mcmc,
+                 color="dodgerblue", lw=0.5, linestyle='dashed')
+        plt.plot(updatedmcmc['snd'], color="dodgerblue", lw=1,
+                 label="Updated-MCMC")
+    except Exception:
+        pass
+
+    plt.plot(ol['snd'], color="black", lw=0.8,
+             label="Reference run")
+    plt.scatter(x, y, color="cornflowerblue", edgecolors='black', s=9,
+                label="Observations")
+
+    plt.legend(loc='center left', bbox_to_anchor=(1, 0.5))
 
 
-plt.plot(ol['snd'], color="black", lw=0.8,
-         label="Reference run")
-plt.scatter(x, y, color="cornflowerblue", edgecolors='black', s=9,
-            label="Observations")
+if __name__ == "__main__":
+    main(output_file)
 
-
-plt.legend(loc='center left', bbox_to_anchor=(1, 0.5))


### PR DESCRIPTION
1) Adaptive MCMC is no longer hard coded, so non-adaptive MCMC will also work from the config.
2) Fixed an error in the proposal covariance matrix in IES-MCMC.
3) Added adaptive MCMC as an option also in the emulation-based MCMC scheme (IES-MCMC-AI).
I've tested that both adaptive and non-adaptive MCMC schemes work both with the full model and with an emulator. As expected, the adaptive schemes seem to perform best in the sense that they mix faster and have near optimal acceptance rates.

All the major changes I made are in filters.py, the rest is basically untouched (other than which scheme is enabled in the config)