### PR TITLE
Add option to spatially propagate only the observations of a specific variable.

### DIFF
--- a/config.py
+++ b/config.py
@@ -86,6 +86,10 @@ save_ensemble = False
 # implementation from "point_scale", "distributed" or "Spatial_propagation"
 implementation = "point_scale"
 
+# if implementation = "Spatial_propagation" : specify which observation variables are spatially propagated
+# if var_to_prop = False -> than all the var_to_assim are spatially propagated
+var_to_prop = False
+
 # parallelization from "sequential", "multiprocessing" or "PBS.array"
 parallelization = "sequential"
 MPI = False  # Note: not tested

--- a/modules/internal_fns.py
+++ b/modules/internal_fns.py
@@ -391,7 +391,7 @@ def simulation_steps(observations, dates_obs):
         obs_idx = obs_idx[check]
     else:
         obs_values = observations[obs_idx, :]
-        check = np.all(~np.isnan(obs_values), axis=1)
+        check = ~np.all(np.isnan(obs_values), axis=1)
         obs_idx = obs_idx[check]
 
     days = [date.day for date in del_t]

--- a/modules/spatialMuSA.py
+++ b/modules/spatialMuSA.py
@@ -742,18 +742,25 @@ def get_neig_info(lat_idx, lon_idx, step, j):
 
     var_to_assim = cfg.var_to_assim
     # r_cov = cfg.r_cov
+    
+    var_to_prop = cfg.var_to_prop
+    if var_to_prop == False:
+        var_to_prop = var_to_assim
+    
+    pos = []
+    [pos.append(var_to_assim.index(x)) for x in var_to_prop]
 
     for count, file in enumerate(files):
 
         ens_tmp = ifn.io_read(file)
-        obs = ens_tmp.observations
-        errors = ens_tmp.errors
+        obs = ens_tmp.observations[:,pos]
+        errors = ens_tmp.errors[:,pos]
 
         if np.isnan(obs).all():
             continue
 
         list_state = ens_tmp.state_membres
-        predicted = flt.get_predictions(list_state, var_to_assim)
+        predicted = flt.get_predictions(list_state, var_to_prop)
 
         obs_masked, predicted, tmp_r_cov = \
             flt.tidy_obs_pred_rcov(predicted, obs, errors)

--- a/modules/spatialMuSA.py
+++ b/modules/spatialMuSA.py
@@ -753,8 +753,13 @@ def get_neig_info(lat_idx, lon_idx, step, j):
     for count, file in enumerate(files):
 
         ens_tmp = ifn.io_read(file)
-        obs = ens_tmp.observations[:,pos]
-        errors = ens_tmp.errors[:,pos]
+
+        if len(var_to_prop)>1:
+            obs = ens_tmp.observations[:,pos]
+            errors = ens_tmp.errors[:,pos]
+        else:
+            obs = ens_tmp.observations
+            errors = ens_tmp.errors
 
         if np.isnan(obs).all():
             continue

--- a/modules/spatialMuSA.py
+++ b/modules/spatialMuSA.py
@@ -608,8 +608,8 @@ def obs_mask():
                 nc_value = nc_value.filled(np.nan)
                 tmp_storage.extend(nc_value)
                 data_temp.close()
-            
 
+            
     tmp_storage = np.dstack(tmp_storage)
     tmp_storage = np.moveaxis(tmp_storage, 2, 0)
     tmp_storage[~np.isnan(tmp_storage)] = 1


### PR DESCRIPTION
Hi @ealonsogzl, @krisaalstad,

I've tried to do experiment with joint assimilation of fSCA from S2 and ICESat-2.
I don't think it makes any sense (both in terms of efficiency, and in statistical terms) to spatially propagate fSCA as they are spatially distributed. 
Hence I tried to add the possibility for the user to select the variables whose observations you want to spatially propagate.
In the config.py file, I added a var_to_prop variable.
 if set to false, var_to_prop = var_to_assim.
Otherwise, the var_to_prop variable is used in the modules/spatial_MuSA.get_neig_info() function to select only neighbouring observations of the variables we want to propagate. 

Let me know if you think this makes sense. My first simulations seem okay. Let me know if you think I have to modify smthing else.

Cheers,
Marco,