### PR TITLE
Bug in get_neig_info with the new observation flag.

### DIFF
--- a/modules/spatialMuSA.py
+++ b/modules/spatialMuSA.py
@@ -737,14 +737,15 @@ def create_neigb(lat_idx, lon_idx, step, j):
 def get_neig_info(lat_idx, lon_idx, step, j):
 
     files = create_neigb(lat_idx, lon_idx, step, j)
-    if len(files) == 0:
-        return None
-
+    
     neig_obs = []
     neig_pred_obs = []
     neig_r_cov = []
     neig_lat = []
     neig_long = []
+    
+    if len(files) == 0:
+        return neig_obs, neig_pred_obs, neig_r_cov, neig_lat, neig_long
 
     var_to_assim = cfg.var_to_assim
     # r_cov = cfg.r_cov
@@ -1062,7 +1063,8 @@ def spatial_assim(lat_idx, lon_idx, step, j):
         #in case var_to_prop exists, get_neig_info gets only the neigborhood obs and not the local observation:
         #add the local observations and coordinates in case of var_to_prop != False.
         if cfg.var_to_prop != False:
-		    neig_obs, neig_pred_obs, neig_r_cov = \
+            
+            neig_obs, neig_pred_obs, neig_r_cov = \
 		    	add_local_obs(Ensemble, neig_obs, neig_pred_obs, neig_r_cov)
 		    	
 		    #add the coordinates of the local obs


### PR DESCRIPTION
I got an error while running a simulation and assimilation of snowdepth ( observed in a few cells and with spatial propagation turned on). 
the error was 
"(cannot unpack non-iterable NoneType object)  Cel not updated: ...."

I think the problem was that in cells with no local observation and an empty neighborhood, the function get_neig_info was returning a single None: that cannot be assigned to neig_obs, neig_pred_obs, neig_r_cov, neig_lat, neig_long..

So I fixed it by returning 5 empty lists if the neighborhood is empty. In case there is a local obs (of a variable to be propagated, that information can be added to the lists with the add_local.... functinos.

@ealonsogzl let me know if it feels right.

Cheers,
Marco.

