### PR TITLE
make var_to_prop always a list.

### DIFF
--- a/config.py
+++ b/config.py
@@ -86,10 +86,10 @@ save_ensemble = False
 # implementation from "point_scale", "distributed" or "Spatial_propagation"
 implementation = "distributed"
 
-# if implementation = "Spatial_propagation" : specify which observation
-# variables are spatially propagated
-# if var_to_prop = False -> than all the var_to_assim are spatially propagated
-var_to_prop = False
+# if implementation = "Spatial_propagation" : specify which observation variables are spatially propagated in a list
+# if var_to_prop = var_to_assim -> than all the var_to_assim are spatially propagated
+# if var_to_prop = [] -> no observations are spatially propagated
+var_to_prop = var_to_assim
 
 # parallelization from "sequential", "multiprocessing" or "PBS.array"
 parallelization = "multiprocessing"


### PR DESCRIPTION
response to PR #16.

I had to change a few things in the functions add_local_... and get_neig_info, partly because now var_to_prop is always a list and partly because I had not tested all the possibilities before. I believe now I tested all the combinations of cells with yes/no obs, and variables to yes/no spatially propagate. Hope I didn't miss anything.

Cheers,
Marco.