### PR TITLE
Add option to export more metrics (min, max, median...) or at daily time steps. Correct typos.

### DIFF
--- a/config.py
+++ b/config.py
@@ -241,7 +241,7 @@ lon_obs_var_name = "easting"
 # Press_var_name can be "Press_var_name": "from_DEM". With this option, a
 # stationary pressure value is estimated from the DEM (if provided)
 # assuming standard atmosphere.
-frocing_var_names = {"SW_var_name": "SW",
+forcing_var_names = {"SW_var_name": "SW",
                      "LW_var_name": "LW",
                      "Precip_var_name": "PRECC",
                      "Press_var_name": "PRESS",
@@ -288,3 +288,14 @@ EXCHNG = 1   # turbulent exchange            : 0, 1
 HYDROL = 2   # snow hydraulics               : 0, 1, 2
 SGRAIN = 2   # snow grain growth             : 1, 2
 SNFRAC = 3   # snow cover fraction           : 1, 2, 3
+
+# -----------------------------------
+# Export option
+# -----------------------------------
+
+# If True, the min, max, 1st, 3rd quartile, median, mean and std will be exported. 
+# Otherwise, only the mean and std. 
+write_stat_full = False 
+
+# if True, the output are averaged at daily time step.
+write_stat_daily = False

--- a/main.py
+++ b/main.py
@@ -276,6 +276,11 @@ def MuSA():
     else:
         raise Exception("Choose an available implementation")
 
+    if cfg.write_stat_full and cfg.restart_run:
+        raise Exception("write_stat_full and restart_run cannot be activated simultaneously. To be implemented.")
+
+    if cfg.write_stat_daily and cfg.restart_run:
+        raise Exception("write_stat_daily and restart_run cannot be activated simultaneously. To be implemented.")
 
 def check_platform():
 

--- a/modules/dIm_tools.py
+++ b/modules/dIm_tools.py
@@ -176,8 +176,8 @@ def storeDA(Result_df, step_results, observations_sbst, error_sbst,
     var_to_assim = cfg.var_to_assim
     error_names = cfg.obs_error_var_names
 
-    rowIndex = Result_df.index[time_dict["Assimilaiton_steps"][step]:
-                               time_dict["Assimilaiton_steps"][step + 1]]
+    rowIndex = Result_df.index[time_dict["Assimilation_steps"][step]:
+                               time_dict["Assimilation_steps"][step + 1]]
 
     if len(var_to_assim) > 1:
         for i, var in enumerate(var_to_assim):
@@ -205,16 +205,22 @@ def storeOL(OL_FSM, Ensemble, observations_sbst, time_dict, step):
         OL_FSM[name_col] = ol_data.iloc[:, [n]].to_numpy()
 
 
-def store_sim(updated_Sim, sd_Sim, Ensemble,
-              time_dict, step, MCMC=False, save_prior=False):
+def store_sim( Ensemble, time_dict, step, MCMC=False, save_prior=False):
 
+    if cfg.write_stat_full:
+        stat_name_list = ['min', 'max', 'Q1', 'Q3', 'median', 'mean', 'std']
+    else:
+        stat_name_list = ['mean', 'std']
+        
+    sim_stat = {key: init_result(time_dict["del_t"]) for key in stat_name_list}
+            
     if MCMC:
         list_state = copy.deepcopy(Ensemble.state_members_mcmc)
     else:
         list_state = copy.deepcopy(Ensemble.state_membres)
 
-    rowIndex = updated_Sim.index[time_dict["Assimilaiton_steps"][step]:
-                                 time_dict["Assimilaiton_steps"][step + 1]]
+    rowIndex = sim_stat['mean'].index[time_dict["Assimilation_steps"][step]:
+                                 time_dict["Assimilation_steps"][step + 1]]
 
     # Get updated columns
     if save_prior:
@@ -223,18 +229,28 @@ def store_sim(updated_Sim, sd_Sim, Ensemble,
         pesos = Ensemble.wgth
 
     for n, name_col in enumerate(list(list_state[0].columns)):
+
         # create matrix of colums
         col_arr = [list_state[x].iloc[:, n].to_numpy()
                    for x in range(len(list_state))]
         col_arr = np.vstack(col_arr)
-
+        
         d1 = DescrStatsW(col_arr, weights=pesos)
-        average_sim = d1.mean
-        sd_sim = d1.std
 
-        updated_Sim.loc[rowIndex, name_col] = average_sim
-        sd_Sim.loc[rowIndex, name_col] = sd_sim
-
+        if len( sim_stat.keys()) == 2: # Mean, Std 
+            sim_stat['mean'].loc[rowIndex, name_col] = d1.mean
+            sim_stat['std'].loc[rowIndex, name_col] = d1.std
+        else:  
+            perc = d1.quantile([ 0, 0.25, 0.5, 0.75, 1 ]).values
+            sim_stat['min'].loc[rowIndex, name_col] = perc[0,:]
+            sim_stat['Q1'].loc[rowIndex, name_col] = perc[1,:]
+            sim_stat['median'].loc[rowIndex, name_col] = perc[2,:]
+            sim_stat['Q3'].loc[rowIndex, name_col] = perc[3,:]
+            sim_stat['max'].loc[rowIndex, name_col] = perc[4,:]
+            sim_stat['mean'].loc[rowIndex, name_col] = d1.mean
+            sim_stat['std'].loc[rowIndex, name_col] = d1.std
+    return sim_stat
+            
 
 def init_result(del_t, DA=False):
 
@@ -263,7 +279,7 @@ def init_result(del_t, DA=False):
 def forcing_table(lat_idx, lon_idx, step=0):
 
     nc_forcing_path = cfg.nc_forcing_path
-    frocing_var_names = cfg.frocing_var_names
+    forcing_var_names = cfg.forcing_var_names
     param_var_names = cfg.param_var_names
     date_ini = cfg.date_ini
     date_end = cfg.date_end
@@ -285,15 +301,15 @@ def forcing_table(lat_idx, lon_idx, step=0):
     else:
 
         prec = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                    frocing_var_names["Precip_var_name"],
+                                    forcing_var_names["Precip_var_name"],
                                     date_ini, date_end)
 
         temp = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                    frocing_var_names["Temp_var_name"],
+                                    forcing_var_names["Temp_var_name"],
                                     date_ini, date_end)
 
         rel_humidity = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                            frocing_var_names["RH_var_name"],
+                                            forcing_var_names["RH_var_name"],
                                             date_ini, date_end)
         try:
             DMF = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,

--- a/modules/fsm_tools.py
+++ b/modules/fsm_tools.py
@@ -280,7 +280,7 @@ def model_read_output(fsm_path, read_dump=True):
     # add optional variables
     if cfg.DAsord:
         state = snd_ord(state)
-
+    
     if (state.isnull().values.any()):
         error_dir = shutil.copytree(fsm_path,
                                     "./DATA/ERRORS/{cords}".
@@ -534,8 +534,8 @@ def storeDA(Result_df, step_results, observations_sbst, error_sbst,
     var_to_assim = cfg.var_to_assim
     error_names = cfg.obs_error_var_names
 
-    rowIndex = Result_df.index[time_dict["Assimilaiton_steps"][step]:
-                               time_dict["Assimilaiton_steps"][step + 1]]
+    rowIndex = Result_df.index[time_dict["Assimilation_steps"][step]:
+                               time_dict["Assimilation_steps"][step + 1]]
 
     if len(var_to_assim) > 1:
         for i, var in enumerate(var_to_assim):
@@ -565,9 +565,15 @@ def storeOL(OL_FSM, Ensemble, observations_sbst, time_dict, step):
         OL_FSM[name_col] = ol_data.iloc[:, [n]].to_numpy()
 
 
-def store_sim(updated_Sim, sd_Sim, Ensemble,
-              time_dict, step, MCMC=False, save_prior=False):
+def store_sim( Ensemble, time_dict, step, MCMC=False, save_prior=False):
 
+    if cfg.write_stat_full:
+        stat_name_list = ['min', 'max', 'Q1', 'Q3', 'median', 'mean', 'std']
+    else:
+        stat_name_list = ['mean', 'std']
+        
+    sim_stat = {key: init_result(time_dict["del_t"]) for key in stat_name_list}
+            
     if MCMC:
         list_state = copy.deepcopy(Ensemble.state_members_mcmc)
     else:
@@ -575,8 +581,8 @@ def store_sim(updated_Sim, sd_Sim, Ensemble,
     # remove time ids fomr FSM output
     # TODO: modify directly FSM code to not to output time id's
 
-    rowIndex = updated_Sim.index[time_dict["Assimilaiton_steps"][step]:
-                                 time_dict["Assimilaiton_steps"][step + 1]]
+    rowIndex = sim_stat['mean'].index[time_dict["Assimilation_steps"][step]:
+                                 time_dict["Assimilation_steps"][step + 1]]
 
     if save_prior:
         pesos = np.ones_like(Ensemble.wgth)
@@ -589,15 +595,23 @@ def store_sim(updated_Sim, sd_Sim, Ensemble,
         col_arr = [list_state[x].iloc[:, n].to_numpy()
                    for x in range(len(list_state))]
         col_arr = np.vstack(col_arr)
-
+        
         d1 = DescrStatsW(col_arr, weights=pesos)
-        average_sim = d1.mean
-        sd_sim = d1.std
 
-        updated_Sim.loc[rowIndex, name_col] = average_sim
-        sd_Sim.loc[rowIndex, name_col] = sd_sim
-
-
+        if len( sim_stat.keys()) == 2: # Mean, Std 
+            sim_stat['mean'].loc[rowIndex, name_col] = d1.mean
+            sim_stat['std'].loc[rowIndex, name_col] = d1.std
+        else:  
+            perc = d1.quantile([ 0, 0.25, 0.5, 0.75, 1 ]).values
+            sim_stat['min'].loc[rowIndex, name_col] = perc[0,:]
+            sim_stat['Q1'].loc[rowIndex, name_col] = perc[1,:]
+            sim_stat['median'].loc[rowIndex, name_col] = perc[2,:]
+            sim_stat['Q3'].loc[rowIndex, name_col] = perc[3,:]
+            sim_stat['max'].loc[rowIndex, name_col] = perc[4,:]
+            sim_stat['mean'].loc[rowIndex, name_col] = d1.mean
+            sim_stat['std'].loc[rowIndex, name_col] = d1.std
+    return sim_stat
+            
 def init_result(del_t, DA=False):
 
     if DA:
@@ -628,7 +642,7 @@ def init_result(del_t, DA=False):
 def forcing_table(lat_idx, lon_idx, step=0):
 
     nc_forcing_path = cfg.nc_forcing_path
-    frocing_var_names = cfg.frocing_var_names
+    forcing_var_names = cfg.forcing_var_names
     param_var_names = cfg.param_var_names
     date_ini = cfg.date_ini
     date_end = cfg.date_end
@@ -650,30 +664,30 @@ def forcing_table(lat_idx, lon_idx, step=0):
     else:
 
         short_w = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                       frocing_var_names["SW_var_name"],
+                                       forcing_var_names["SW_var_name"],
                                        date_ini, date_end)
 
         long_wave = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                         frocing_var_names["LW_var_name"],
+                                         forcing_var_names["LW_var_name"],
                                          date_ini, date_end)
 
         prec = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                    frocing_var_names["Precip_var_name"],
+                                    forcing_var_names["Precip_var_name"],
                                     date_ini, date_end)
 
         temp = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                    frocing_var_names["Temp_var_name"],
+                                    forcing_var_names["Temp_var_name"],
                                     date_ini, date_end)
 
         rel_humidity = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                            frocing_var_names["RH_var_name"],
+                                            forcing_var_names["RH_var_name"],
                                             date_ini, date_end)
 
         wind = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                    frocing_var_names["Wind_var_name"],
+                                    forcing_var_names["Wind_var_name"],
                                     date_ini, date_end)
 
-        if frocing_var_names["Press_var_name"] == "from_DEM":
+        if forcing_var_names["Press_var_name"] == "from_DEM":
 
             with nc.Dataset(cfg.dem_path) as dem:
                 topo = dem.variables[cfg.nc_dem_varname][lat_idx, lon_idx]
@@ -682,7 +696,7 @@ def forcing_table(lat_idx, lon_idx, step=0):
 
         else:
             press = ifn.nc_array_forcing(nc_forcing_path, lat_idx, lon_idx,
-                                         frocing_var_names["Press_var_name"],
+                                         forcing_var_names["Press_var_name"],
                                          date_ini, date_end)
 
         # Search for parameters or use the default settings

--- a/modules/internal_fns.py
+++ b/modules/internal_fns.py
@@ -597,7 +597,7 @@ def simulation_steps(observations, dates_obs):
 
     return {"del_t": del_t,
             "obs_idx": obs_idx,
-            "Assimilaiton_steps": assimilation_steps}
+            "Assimilation_steps": assimilation_steps}
 
 
 def run_model_openloop(lat_idx, lon_idx, main_forcing, filename):

--- a/modules/spatialMuSA.py
+++ b/modules/spatialMuSA.py
@@ -1131,15 +1131,15 @@ def create_ensemble_cell(lat_idx, lon_idx, ini_DA_window, step, gsc_count):
                                                                     step)
     # subset forcing and observations
     # subset forcing, errors and observations
-    observations_sbst = observations[time_dict["Assimilaiton_steps"][step]:
-                                     time_dict["Assimilaiton_steps"][step
+    observations_sbst = observations[time_dict["Assimilation_steps"][step]:
+                                     time_dict["Assimilation_steps"][step
                                                                      + 1]]
-    error_sbst = errors[time_dict["Assimilaiton_steps"][step]:
-                        time_dict["Assimilaiton_steps"][step
+    error_sbst = errors[time_dict["Assimilation_steps"][step]:
+                        time_dict["Assimilation_steps"][step
                                                         + 1]]
 
-    forcing_sbst = main_forcing[time_dict["Assimilaiton_steps"][step]:
-                                time_dict["Assimilaiton_steps"][step + 1]]\
+    forcing_sbst = main_forcing[time_dict["Assimilation_steps"][step]:
+                                time_dict["Assimilation_steps"][step + 1]]\
         .copy()
 
     obs_flag = ~np.isnan(observations_sbst).all()
@@ -1194,7 +1194,7 @@ def create_ensemble_cell(lat_idx, lon_idx, ini_DA_window, step, gsc_count):
 
     # Ensemble.create(forcing_sbst, observations_sbst, error_sbst, step)
 
-    if time_dict["Assimilaiton_steps"][step] in ini_DA_window:
+    if time_dict["Assimilation_steps"][step] in ini_DA_window:
         GSC_filename = (str(gsc_count) + '_GSC.nc')
 
         Ensemble.create(forcing_sbst, observations_sbst, error_sbst,  step,
@@ -1438,7 +1438,7 @@ def collect_results(lat_idx, lon_idx):
     OL_Sim = model.init_result(del_t)       # OL simulation
 
     # HACK: fake time_dict
-    time_dict = {'Assimilaiton_steps':
+    time_dict = {'Assimilation_steps':
                  np.append(ini_DA_window, len(del_t))}
 
     # loop over DA steps


### PR DESCRIPTION
Add option to export more metrics (min, max, median, quartiles): option write_stat_full. 
Add option to export the output averaged at daily time step: option write_stat_daily.
Note that these options are probably not compatible with restart_run option (to be checked).
An exception was added to main.py

Correct typos (frocing, assimilaiton). Code should be faster now.